### PR TITLE
Fix/default transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Edit the file in `./config/default.json` to configure the logger, or set the fol
 
 | Environment variable | Description | Default | Available Values |
 | --- | --- | --- | --- |
-| `LOG_LEVEL` | See `CSL_LOG_LEVEL` | `info` | `error`, `warn`, `audit`, `trace`, `info`, `perf`, `verbose`, `debug`, `silly` |
+| `LOG_LEVEL` | Also `CSL_LOG_LEVEL` | `info` | `error`, `warn`, `audit`, `trace`, `info`, `perf`, `verbose`, `debug`, `silly` |
 | `CSL_LOG_LEVEL` | Sets the log level | `info` | `error`, `warn`, `audit`, `trace`, `info`, `perf`, `verbose`, `debug`, `silly` |
-| `LOG_FILTER` | See `CSL_LOG_FILTER` | `""` | e.g. `"error, trace, verbose" | 
+| `LOG_FILTER` | Also `CSL_LOG_FILTER` | `""` | e.g. `"error, trace, verbose" | 
 | `CSL_LOG_FILTER` | Applies a log filter. Specify a comma separated list of individual log levels to be included instead of specifying a `LOG_LEVEL` | `""` | e.g. `"error, trace, verbose" |
 | `CSL_LOG_TRANSPORT` | Selects the transport method. Either `console` or `file`. Uses the same transport for errors and standard logs | `console` | `console`, `file`
 | `CSL_TRANSPORT_FILE_OPTIONS` | _Optional._ Required if `LOG_TRANSPORT=file`. Configures the winston file transport | See `default.json` | See the [Winston Docs](https://github.com/winstonjs/winston#common-transport-options) |

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Edit the file in `./config/default.json` to configure the logger, or set the fol
 
 | Environment variable | Description | Default | Available Values |
 | --- | --- | --- | --- |
-| `LOG_LEVEL` | _deprecated_ Use `CSL_LOG_LEVEL` instead | `info` | `error`, `warn`, `audit`, `trace`, `info`, `perf`, `verbose`, `debug`, `silly` |
+| `LOG_LEVEL` | See `CSL_LOG_LEVEL` | `info` | `error`, `warn`, `audit`, `trace`, `info`, `perf`, `verbose`, `debug`, `silly` |
 | `CSL_LOG_LEVEL` | Sets the log level | `info` | `error`, `warn`, `audit`, `trace`, `info`, `perf`, `verbose`, `debug`, `silly` |
-| `LOG_FILTER` | _deprecated_ Use `CSL_LOG_FILTER` instead | `""` | e.g. `"error, trace, verbose" | 
+| `LOG_FILTER` | See `CSL_LOG_FILTER` | `""` | e.g. `"error, trace, verbose" | 
 | `CSL_LOG_FILTER` | Applies a log filter. Specify a comma separated list of individual log levels to be included instead of specifying a `LOG_LEVEL` | `""` | e.g. `"error, trace, verbose" |
-| `CSL_LOG_TRANSPORT` | Selects the transport method. Either `console` or `file` | `file` | `console`, `file`
+| `CSL_LOG_TRANSPORT` | Selects the transport method. Either `console` or `file`. Uses the same transport for errors and standard logs | `console` | `console`, `file`
 | `CSL_TRANSPORT_FILE_OPTIONS` | _Optional._ Required if `LOG_TRANSPORT=file`. Configures the winston file transport | See `default.json` | See the [Winston Docs](https://github.com/winstonjs/winston#common-transport-options) |
 
 

--- a/config/default.json
+++ b/config/default.json
@@ -1,7 +1,7 @@
 {
   "LOG_LEVEL": "info",
   "LOG_FILTER": "",
-  "LOG_TRANSPORT": "log",
+  "LOG_TRANSPORT": "console",
   "TRANSPORT_FILE_OPTIONS": {
     "json": false,
     "timestamp": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-logger",
-  "version": "8.5.4",
+  "version": "8.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-logger",
-  "version": "8.5.2",
+  "version": "8.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-logger",
-  "version": "8.5.2",
+  "version": "8.5.4",
   "description": "Mojaloop common logging library",
   "main": "src/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-logger",
-  "version": "8.5.4",
+  "version": "8.6.0",
   "description": "Mojaloop common logging library",
   "main": "src/index.js",
   "repository": {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,4 +1,4 @@
-const RC = require('parse-strings-in-object')(require('rc')('CSL_', require('../../config/default.json')))
+const RC = require('parse-strings-in-object')(require('rc')('CSL', require('../../config/default.json')))
 
 const Config = {
   // note: We maintain the LOG_LEVEL and LOG_FILTER env variable here to ensure backwards compatibility to before we used RC


### PR DESCRIPTION
- fixes the default transport in central-services-logger to be `console`
- remove unneeded underscore in `config.js`