### PR TITLE
feat: multiple configurable transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,31 @@ Edit the file in `./config/default.json` to configure the logger, or set the fol
 | `CSL_LOG_LEVEL` | Sets the log level | `info` | `error`, `warn`, `audit`, `trace`, `info`, `perf`, `verbose`, `debug`, `silly` |
 | `LOG_FILTER` | Also `CSL_LOG_FILTER` | `""` | e.g. `"error, trace, verbose" |
 | `CSL_LOG_FILTER` | Applies a log filter. Specify a comma separated list of individual log levels to be included instead of specifying a `LOG_LEVEL` | `""` | e.g. `"error, trace, verbose" |
-| `CSL_LOG_TRANSPORT` | Selects the transport method. Either `console` or `file`. Uses the same transport for errors and standard logs | `console` | `console`, `file`
+| `CSL_LOG_TRANSPORT` | Selects the transport method. Either `console`, `file` or a map for multiple transports. Uses the same transport for errors and standard logs | `console` | `console`, `file`, `{}` |
 | `CSL_TRANSPORT_FILE_OPTIONS` | _Optional._ Required if `LOG_TRANSPORT=file`. Configures the winston file transport | See `default.json` | See the [Winston Docs](https://github.com/winstonjs/winston#common-transport-options) |
 | `CSL_JSON_STRINGIFY_SPACING` |  _Optional._  A number that's used to insert white space into the output JSON string for readability purposes. | 2 | integer
 
+### Configuring multiple transports
 
+The `CSL_LOG_TRANSPORT` environment variable can be set to a JSON object to
+configure multiple transports. The key names can be any string, and the values
+should be objects that contain the transport type and configuration, e.g.:
+
+```json
+{
+  "stdout": {
+    "type": "console"
+  },
+  "fluentbit": {
+    "type": "udp",
+    "host": "fluentbit"
+  },
+  "combined": {
+    "type": "file",
+    "filename": "combined.log"
+  }
+}
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,26 @@ should be objects that contain the transport type and configuration, e.g.:
 }
 ```
 
+### UDP Transport
+
+The `udp` transport is a custom transport that sends logs to a remote server
+via UDP. The following configuration options are available:
+
+| Option     | Description                                     | Default   | Required |
+| ---        | ---                                             | ---       | ---      |
+| `host`     | The hostname or IP address of the remote server | localhost | No       |
+| `port`     | The port number of the remote server            | 5170      | No       |
+| `mtu`      | The maximum size of a single packet in bytes    | 1400      | No       |
+| `max`      | The maximum size of logged message              | 4096      | No       |
+| `id`       | Optional id to put in front of each packet      | false     | No       |
+
+- Messages above the `max` size will not be sent.
+- `id` is useful for identifying the source of the logs on the remote server.
+  It can be set to `true` to generate a random id, or a hex string to use a
+  specific id.
+- `mtu` should be set to the maximum packet size that the network can handle.
+  Messages that are too large will be split into multiple network packets.
+
 ## Usage
 
 ### Logger

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,12 @@
         "winston": "3.17.0"
       },
       "devDependencies": {
-        "@types/node": "22.13.4",
+        "@types/node": "22.13.10",
         "audit-ci": "^7.1.0",
         "husky": "9.1.7",
         "jest": "^29.7.0",
         "license-checker": "25.0.1",
-        "npm-check-updates": "17.1.14",
+        "npm-check-updates": "17.1.15",
         "nyc": "17.1.0",
         "proxyquire": "2.1.3",
         "replace": "^1.2.2",
@@ -1249,10 +1249,11 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.13.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
-      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -7372,10 +7373,11 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "17.1.14",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.14.tgz",
-      "integrity": "sha512-dr4bXIxETubLI1tFGeock5hN8yVjahvaVpx+lPO4/O2md3zJuxB7FgH3MIoTvQSCgsgkIRpe0skti01IEAA5tA==",
+      "version": "17.1.15",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.15.tgz",
+      "integrity": "sha512-miATvKu5rjec/1wxc5TGDjpsucgtCHwRVZorZpDkS6NzdWXfnUWlN4abZddWb7XSijAuBNzzYglIdTm9SbgMVg==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "ncu": "build/cli.js",
         "npm-check-updates": "build/cli.js"

--- a/package.json
+++ b/package.json
@@ -71,12 +71,12 @@
     "winston": "3.17.0"
   },
   "devDependencies": {
-    "@types/node": "22.13.4",
+    "@types/node": "22.13.10",
     "audit-ci": "^7.1.0",
     "husky": "9.1.7",
     "jest": "^29.7.0",
     "license-checker": "25.0.1",
-    "npm-check-updates": "17.1.14",
+    "npm-check-updates": "17.1.15",
     "nyc": "17.1.0",
     "proxyquire": "2.1.3",
     "replace": "^1.2.2",

--- a/src/ConsoleTransport.js
+++ b/src/ConsoleTransport.js
@@ -1,0 +1,27 @@
+const stringify = require('safe-stable-stringify')
+const { jsonStringifySpacing } = require('./lib/config')
+
+const { transports: { Console }, format: { combine, colorize, printf } } = require('winston')
+
+const customFormat = printf(({ level, message, timestamp, ...rest }) => {
+  const contextString = Object.values(rest).filter(value => value !== undefined).length ? '\t' + stringify(rest, null, jsonStringifySpacing) : ''
+  return `${timestamp} - ${level}: ${message}${contextString}`
+})
+
+module.exports = class ConsoleTransport extends Console {
+  constructor (options) {
+    super({
+      format: combine(
+        colorize({
+          colors: {
+            audit: 'magenta',
+            trace: 'white',
+            perf: 'green'
+          }
+        }),
+        customFormat
+      ),
+      ...options
+    })
+  }
+}

--- a/src/ConsoleTransport.js
+++ b/src/ConsoleTransport.js
@@ -4,7 +4,7 @@ const { jsonStringifySpacing } = require('./lib/config')
 const { transports: { Console }, format: { combine, colorize, printf } } = require('winston')
 
 const customFormat = printf(({ level, message, timestamp, ...rest }) => {
-  const contextString = Object.values(rest).filter(value => value !== undefined).length ? '\t' + stringify(rest, null, jsonStringifySpacing) : ''
+  const contextString = Object.values(rest).filter(value => value !== undefined).length ? ' -\t' + stringify(rest, null, jsonStringifySpacing) : ''
   return `${timestamp} - ${level}: ${message}${contextString}`
 })
 

--- a/src/UdpTransport.js
+++ b/src/UdpTransport.js
@@ -29,7 +29,7 @@ class UdpStream extends stream.Writable {
     this.socket = udp.createSocket(this.config.type || 'udp4')
     this.socket.unref()
     this.id = this.createId()
-    this.mtu = (this.config.mtu || 1400) - this.id.length
+    this.mtu = this.config.mtu - this.id.length
     this.socket.on('message', this.handleMessage.bind(this))
     this.on('error', () => console.error) // ignore udp errors
   }
@@ -89,6 +89,9 @@ module.exports = class UdpTransport extends winston.transports.Stream {
         objectMode: true,
         host: 'localhost',
         port: 5170,
+        id: false,
+        max: 4096,
+        mtu: 1400,
         ...config
       })
     })

--- a/src/UdpTransport.js
+++ b/src/UdpTransport.js
@@ -1,0 +1,98 @@
+const udp = require('dgram')
+const stream = require('readable-stream')
+const crypto = require('crypto')
+const winston = require('winston')
+
+class UdpStream extends stream.Writable {
+  constructor (config) {
+    super({ autoDestroy: true, ...config })
+    this.config = config || {}
+    this.host = this.config.host
+    this.port = this.config.port
+    this.max = this.config.max
+    this.createSocket()
+  }
+
+  // Create an optional random id for the stream in case of proxying
+  createId () {
+    if (this.config.id === true) {
+      return crypto.randomBytes(16)
+    } else if (this.config.id) {
+      return Buffer.from(this.config.id, 'hex')
+    } else return Buffer.alloc(0)
+  }
+
+  createSocket () {
+    if (this.socket) {
+      this.socket.close()
+    }
+    this.socket = udp.createSocket(this.config.type || 'udp4')
+    this.id = this.createId()
+    this.mtu = (this.config.mtu || 1400) - this.id.length
+    this.socket.on('message', this.handleMessage.bind(this))
+    this.on('error', () => console.error) // ignore udp errors
+  }
+
+  handleMessage (msg) {
+    try {
+      msg = JSON.parse(msg.toString('utf8'))
+      if (msg && msg.method === 'restart') this.id = this.createId()
+    } catch (e) {
+      // ignore invalid messages
+    }
+  }
+
+  _write (message, encoding, done) {
+    if (typeof message === 'object') {
+      message = Buffer.from(JSON.stringify(message) + '\n', encoding)
+    } else if (typeof message === 'string') {
+      message = Buffer.from(message, encoding)
+    }
+    if (this.max && message && message.length > this.max) {
+      done()
+      return
+    }
+    const id = this.id.subarray()
+    const send = (start, length, cb) => {
+      this.socket.send(Buffer.concat([id, message.slice(start, start + length)]), this.port, this.host, cb)
+    }
+    const callback = err => {
+      if (err) {
+        console.error(err)
+        this.createSocket()
+      }
+      done()
+    }
+    const sendFrame = (start, length) => {
+      if (start + length >= message.length) {
+        send(start, message.length - start, callback)
+      } else {
+        send(start, length, err => {
+          if (err) {
+            callback(err)
+          } else {
+            setImmediate(() => sendFrame(start + length, length))
+          }
+        })
+      }
+    }
+    sendFrame(0, this.mtu)
+  }
+
+  _destroy (error, callback) {
+    this.socket.close(err => callback && callback(err || error))
+  }
+}
+
+module.exports = class UdpTransport extends winston.transports.Stream {
+  constructor (config) {
+    super({
+      stream: new UdpStream({
+        objectMode: true,
+        host: 'localhost',
+        port: 5170,
+        ...config
+      })
+    })
+  }
+}

--- a/src/UdpTransport.js
+++ b/src/UdpTransport.js
@@ -6,7 +6,7 @@ const winston = require('winston')
 class UdpStream extends stream.Writable {
   constructor (config) {
     super({ autoDestroy: true, ...config })
-    this.config = config || {}
+    this.config = config
     this.host = this.config.host
     this.port = this.config.port
     this.max = this.config.max
@@ -27,6 +27,7 @@ class UdpStream extends stream.Writable {
       this.socket.close()
     }
     this.socket = udp.createSocket(this.config.type || 'udp4')
+    this.socket.unref()
     this.id = this.createId()
     this.mtu = (this.config.mtu || 1400) - this.id.length
     this.socket.on('message', this.handleMessage.bind(this))
@@ -43,11 +44,8 @@ class UdpStream extends stream.Writable {
   }
 
   _write (message, encoding, done) {
-    if (typeof message === 'object') {
-      message = Buffer.from(JSON.stringify(message) + '\n', encoding)
-    } else if (typeof message === 'string') {
-      message = Buffer.from(message, encoding)
-    }
+    message = Buffer.from(JSON.stringify(message) + '\n', encoding)
+
     if (this.max && message && message.length > this.max) {
       done()
       return

--- a/src/contextLogger.js
+++ b/src/contextLogger.js
@@ -28,7 +28,6 @@
 
 /* eslint-disable space-before-function-paren */
 const { AsyncLocalStorage } = require('node:async_hooks')
-const stringify = require('safe-stable-stringify')
 const createMlLogger = require('./createMlLogger')
 const { allLevels } = require('./lib/constants')
 
@@ -44,39 +43,39 @@ class ContextLogger {
   }
 
   error(message, meta) {
-    this.isErrorEnabled && this.mlLogger.error(this.formatLog(message, meta))
+    this.isErrorEnabled && this.mlLogger.error(...this.formatLog(message, meta))
   }
 
   warn(message, meta) {
-    this.isWarnEnabled && this.mlLogger.warn(this.formatLog(message, meta))
+    this.isWarnEnabled && this.mlLogger.warn(...this.formatLog(message, meta))
   }
 
   info(message, meta) {
-    this.isInfoEnabled && this.mlLogger.info(this.formatLog(message, meta))
+    this.isInfoEnabled && this.mlLogger.info(...this.formatLog(message, meta))
   }
 
   verbose(message, meta) {
-    this.isVerboseEnabled && this.mlLogger.verbose(this.formatLog(message, meta))
+    this.isVerboseEnabled && this.mlLogger.verbose(...this.formatLog(message, meta))
   }
 
   debug(message, meta) {
-    this.isDebugEnabled && this.mlLogger.debug(this.formatLog(message, meta))
+    this.isDebugEnabled && this.mlLogger.debug(...this.formatLog(message, meta))
   }
 
   silly(message, meta) {
-    this.isSillyEnabled && this.mlLogger.silly(this.formatLog(message, meta))
+    this.isSillyEnabled && this.mlLogger.silly(...this.formatLog(message, meta))
   }
 
   audit (message, meta) {
-    this.isAuditEnabled && this.mlLogger.audit(this.formatLog(message, meta))
+    this.isAuditEnabled && this.mlLogger.audit(...this.formatLog(message, meta))
   }
 
   trace(message, meta) {
-    this.isTraceEnabled && this.mlLogger.trace(this.formatLog(message, meta))
+    this.isTraceEnabled && this.mlLogger.trace(...this.formatLog(message, meta))
   }
 
   perf(message, meta) {
-    this.isPerfEnabled && this.mlLogger.perf(this.formatLog(message, meta))
+    this.isPerfEnabled && this.mlLogger.perf(...this.formatLog(message, meta))
   }
 
   child(context) {
@@ -97,13 +96,13 @@ class ContextLogger {
   formatLog(message, meta) {
     const store = asyncStorage.getStore()
 
-    if (!meta && !this.context && !store) return ContextLogger.makeLogString(message)
+    if (!meta && !this.context && !store) return [message]
 
     const metaData = meta instanceof Error
       ? ContextLogger.formatError(meta)
       : typeof meta === 'object' ? meta : { meta }
 
-    return ContextLogger.makeLogString(message, Object.assign({}, store, this.context, metaData))
+    return [message, { ...store, ...this.context, ...metaData }]
   }
 
   createContext(context) {
@@ -122,14 +121,6 @@ class ContextLogger {
     this.isVerboseEnabled = this.mlLogger.isLevelEnabled('verbose')
     this.isDebugEnabled = this.mlLogger.isLevelEnabled('debug')
     this.isSillyEnabled = this.mlLogger.isLevelEnabled('silly')
-  }
-
-  static makeLogString(logMessage, metaData) {
-    const msgString = logMessage instanceof Error
-      ? (logMessage.stack || logMessage.message)
-      : (typeof logMessage === 'object' ? stringify(logMessage) : logMessage)
-
-    return metaData ? `${msgString} - ${stringify(metaData)}` : msgString
   }
 
   static formatError(error) {

--- a/test/jest/contextLogger.test.js
+++ b/test/jest/contextLogger.test.js
@@ -34,7 +34,7 @@ describe('contextLogger Tests -->', () => {
     const spy = jest.spyOn(log.mlLogger, 'info')
     const meta = { a: Date.now() }
     log.info('test', meta)
-    expect(spy.mock.lastCall[0]).toContain(JSON.stringify(meta))
+    expect(spy.mock.lastCall[1]).toMatchObject(meta)
   })
 
   const createPromiseWithAsyncStorage = (data, ms = 500) => {
@@ -52,9 +52,9 @@ describe('contextLogger Tests -->', () => {
     const data = { x: String(Date.now()) }
     const promise = createPromiseWithAsyncStorage(data)
     log.info('test')
-    expect(spy.mock.lastCall[0]).toContain(data.x)
+    expect(spy.mock.lastCall[1]).toMatchObject(data)
     await promise
-    expect(spy.mock.lastCall[0]).toContain(data.x)
+    expect(spy.mock.lastCall[1]).toMatchObject(data)
   })
 
   test('should have access to different async contexts independently', async () => {
@@ -69,9 +69,9 @@ describe('contextLogger Tests -->', () => {
     const promise2 = createPromiseWithAsyncStorage(data2, ms2)
 
     await Promise.all([promise1, promise2])
-    const [[first], [second]] = spy.mock.calls
-    expect(first).toContain(JSON.stringify({ ms: ms2, ...data2 }))
-    expect(second).toContain(JSON.stringify({ ms: ms1, ...data1 }))
+    const [[, first], [, second]] = spy.mock.calls
+    expect(first).toMatchObject({ ms: ms2, ...data2 })
+    expect(second).toMatchObject({ ms: ms1, ...data1 })
   })
 
   test('should set new logLevel', () => {

--- a/test/unit/UdpTransport.test.js
+++ b/test/unit/UdpTransport.test.js
@@ -1,0 +1,71 @@
+const UdpTransport = require('../../src/UdpTransport')
+const dgram = require('dgram')
+const sinon = require('sinon') // Add sinon for mocking
+const Test = require('tapes')(require('tape'))
+
+Test('UdpTransport', (udpTransportTest) => {
+  udpTransportTest.test('should handle messages', (test) => {
+    const udpTransport = new UdpTransport()
+    udpTransport._stream.createSocket()
+    udpTransport._stream.handleMessage(JSON.stringify({ method: 'restart' }))
+    udpTransport._stream.handleMessage('null')
+    udpTransport._stream.handleMessage('')
+
+    test.end()
+  })
+
+  udpTransportTest.test('should use random id prefix', (test) => {
+    const udpTransport = new UdpTransport({ id: true })
+    udpTransport._stream.write({ message: 'test' }, 'utf8', () => {})
+
+    test.end()
+  })
+
+  udpTransportTest.test('should use random configured prefix', (test) => {
+    const udpTransport = new UdpTransport({ id: '00112233445566778899aabbccddeeff' })
+    udpTransport._stream.write({ message: 'test' }, 'utf8', () => {})
+    udpTransport._stream.write({ bigmessage: '0'.repeat(1500) }, 'utf8', () => {})
+
+    test.end()
+  })
+
+  udpTransportTest.test('should skip big messages', (test) => {
+    const udpTransport = new UdpTransport({ max: 10 })
+    udpTransport._stream.write({ message: 'test' }, 'utf8', () => {})
+
+    test.end()
+  })
+
+  udpTransportTest.test('should handle errors', (test) => {
+    const udpTransport = new UdpTransport({ max: 10 })
+    udpTransport._stream.emit('error', new Error('test'))
+    udpTransport._stream.end(new Error('test'))
+
+    test.end()
+  })
+
+  udpTransportTest.test('should ignore DNS errors', (test) => {
+    const udpTransport = new UdpTransport({ host: 'invalidhost' })
+    udpTransport._stream.write({ message: 'test' }, 'utf8', () => {})
+
+    test.end()
+  })
+
+  udpTransportTest.test('should send correct UDP data', (test) => {
+    const udpTransport = new UdpTransport()
+    const socketSendStub = sinon.stub(dgram.Socket.prototype, 'send').callsFake((msg, port, host, callback) => {
+      callback(null)
+    })
+
+    const message = { message: 'test' }
+    udpTransport._stream.write(message, 'utf8', () => {
+      const sentMessage = Buffer.from(JSON.stringify(message) + '\n', 'utf8')
+      test.ok(socketSendStub.calledOnce, 'socket.send should be called once')
+      test.deepEqual(socketSendStub.firstCall.args[0].slice(udpTransport._stream.id.length), sentMessage, 'sent message should match the expected message')
+      socketSendStub.restore()
+      test.end()
+    })
+  })
+
+  udpTransportTest.end()
+})

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -104,7 +104,7 @@ Test('contextual logger', function (loggerTest) {
   loggerTest.test('logger with context formats message properly', function (assert) {
     const logger = Logger.child({ a: 1 })
     logger.info('Message')
-    assert.ok(process.stdout.write.firstCall.args[0].split('info\x1B[39m: ')[1] === 'Message\t' + stringify(
+    assert.ok(process.stdout.write.firstCall.args[0].split('info\x1B[39m: ')[1] === 'Message -\t' + stringify(
       { a: 1 },
       null,
       config.jsonStringifySpacing) + '\n')
@@ -121,7 +121,7 @@ Test('contextual logger', function (loggerTest) {
     obj1.newobj2 = obj2
     const logger = Logger.child({ a: obj2 })
     logger.info('Message')
-    assert.ok(process.stdout.write.firstCall.args[0].split('info\x1B[39m: ')[1] === 'Message\t' + stringify(
+    assert.ok(process.stdout.write.firstCall.args[0].split('info\x1B[39m: ')[1] === 'Message -\t' + stringify(
       { a: obj2 },
       null,
       config.jsonStringifySpacing) + '\n')

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -102,10 +102,10 @@ Test('contextual logger', function (loggerTest) {
   })
 
   loggerTest.test('logger with context formats message properly', function (assert) {
-    const logger = Logger.child({ context: { a: 1 } })
+    const logger = Logger.child({ a: 1 })
     logger.info('Message')
-    assert.ok(process.stdout.write.firstCall.args[0].split('info\x1B[39m: ')[1] === stringify(
-      { a: 1, message: 'Message' },
+    assert.ok(process.stdout.write.firstCall.args[0].split('info\x1B[39m: ')[1] === 'Message\t' + stringify(
+      { a: 1 },
       null,
       config.jsonStringifySpacing) + '\n')
     assert.end()
@@ -119,10 +119,10 @@ Test('contextual logger', function (loggerTest) {
       obj1
     }
     obj1.newobj2 = obj2
-    const logger = Logger.child({ context: { a: obj2 } })
+    const logger = Logger.child({ a: obj2 })
     logger.info('Message')
-    assert.ok(process.stdout.write.firstCall.args[0].split('info\x1B[39m: ')[1] === stringify(
-      { a: obj2, message: 'Message' },
+    assert.ok(process.stdout.write.firstCall.args[0].split('info\x1B[39m: ')[1] === 'Message\t' + stringify(
+      { a: obj2 },
       null,
       config.jsonStringifySpacing) + '\n')
     assert.end()


### PR DESCRIPTION
- enable multiple transports to be configured
- do not stringify logged objects, leave it to the console transport formatter
- move colorization to the console formatter, so that colors are not sent to other transports
- use the same format when logging at the console, regardless of presence of context properties
  ```{time} - {level}: {message}[ -\t{context}]```
- use tab separator to enable easier parsing of the context
- tested to work when OpenTelemetry is auto-injected
- added utp transport, which can be used with lightweight agents like [fluentbit](https://docs.fluentbit.io/manual/pipeline/inputs/udp)