### PR TITLE
fix: use production friendly default

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -9,5 +9,5 @@
     "colorize": true,
     "filename": "logs/combined.log"
   },
-  "JSON_STRINGIFY_SPACING": 2
+  "JSON_STRINGIFY_SPACING": 0
 }


### PR DESCRIPTION
The defaults is better to produce single log lines, so that log aggregation tools like loki can index the logs properly